### PR TITLE
Fix one of the arguments in vscode-ros2.desktop launcher

### DIFF
--- a/.scripts/vscode-ros2.desktop
+++ b/.scripts/vscode-ros2.desktop
@@ -3,7 +3,7 @@ Version=1.0
 Type=Application
 Name=VS Code ROS2
 Icon=/config/.icons/vscode-ros-icon.png
-Exec=code --no-sandbox -- user-data-dir=/tmp --file-uri /ros2.code-workspace
+Exec=code --no-sandbox --user-data-dir=/tmp --file-uri /ros2.code-workspace
 Comment=Open ROS2 Workspace in VS Code
 Categories=Development;IDE;
 Terminal=false


### PR DESCRIPTION
The VS Code launcher wouldnt work without receiving "user-data-dir" correctly.